### PR TITLE
Clean DOM and small refactor

### DIFF
--- a/src/L.Control.SlideMenu.js
+++ b/src/L.Control.SlideMenu.js
@@ -20,8 +20,7 @@ L.Control.SlideMenu = L.Control.extend({
         link.title = 'Menu';
         L.DomUtil.create('span', 'fa fa-bars', link);
 
-        this._menu = L.DomUtil.create('div', 'leaflet-menu', 
-            document.getElementsByClassName('leaflet-container')[0]);    
+        this._menu = L.DomUtil.create('div', 'leaflet-menu', map._container);    
         this._menu.style.width = this.options.width;
         this._menu.style.height = this.options.height;
 
@@ -57,6 +56,13 @@ L.Control.SlideMenu = L.Control.extend({
 
         return this._container;
     },
+    
+    onRemove: function(map){
+		//Remove sliding menu from DOM
+		map._container.removeChild(this._menu);
+		delete this._menu;
+	},
+
 
     setContents: function(innerHTML) {
         this._innerHTML = innerHTML;


### PR DESCRIPTION
Cleans up DOM tree after control removed

References map container by 'map._container' instead of externally through document
(document.getElementsByClassName('leaflet-container')[0])