### PR TITLE
Customize icon for button menu and new methods

### DIFF
--- a/src/L.Control.SlideMenu.js
+++ b/src/L.Control.SlideMenu.js
@@ -7,7 +7,8 @@ L.Control.SlideMenu = L.Control.extend({
         direction: 'horizontal', // vertical or horizontal
         changeperc: '10',
         delay: '10',
-        icon: 'fa-bars'
+        icon: 'fa-bars',
+        hidden: false
     },
 
     initialize: function(innerHTML, options){
@@ -119,6 +120,10 @@ L.Control.SlideMenu = L.Control.extend({
             map.scrollWheelZoom.enable();
         });
 
+        if(this.options.hidden){
+            this.hide();
+        }
+
         return this._container;
     },
 
@@ -160,6 +165,14 @@ L.Control.SlideMenu = L.Control.extend({
         else{
             return;
         }
+    },
+
+    hide: function () {
+        this._container.style.display = 'none';
+    },
+
+    show: function () {
+        this._container.style.display = 'inherit';
     }
 });
 


### PR DESCRIPTION
I added an option for customize icon. The option need the icon name from FontAwesome, for example: `fa fa-map-signs` 

Then you should set the option like this:
`L.control.slideMenu('<p>test</p>', {icon: 'fa-map-signs', width: '200px'}).addTo(map);`

I added two methods and 1 new parameter for hide and show the icon menu.

`var slideMenud = L.control.slideMenu('<p>test</p>', {icon: 'fa-map-signs', width: '200px', hidden: true}).addTo(map);`

And when you want hide/show programatically, you can use:
`slideMenu.show()  or slideMenu.hide()`